### PR TITLE
Parse raw bits if possible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,9 @@ with open(version_py, 'r') as fh:
 
 
 def download_java_files(force=False):
-    files = {'java/javase.jar': 'https://repo1.maven.org/maven2/com/google/zxing/javase/3.4.1/javase-3.4.1.jar',
-             'java/core.jar': 'https://repo1.maven.org/maven2/com/google/zxing/core/3.4.1/core-3.4.1.jar',
-             'java/jcommander.jar': 'https://repo1.maven.org/maven2/com/beust/jcommander/1.78/jcommander-1.78.jar'}
+    files = {'java/javase.jar': 'https://repo1.maven.org/maven2/com/google/zxing/javase/3.5.1/javase-3.5.1.jar',
+             'java/core.jar': 'https://repo1.maven.org/maven2/com/google/zxing/core/3.5.1/core-3.5.1.jar',
+             'java/jcommander.jar': 'https://repo1.maven.org/maven2/com/beust/jcommander/1.82/jcommander-1.82.jar'}
 
     for fn, url in files.items():
         p = path.join(path.dirname(__file__), 'zxing', fn)

--- a/zxing/__init__.py
+++ b/zxing/__init__.py
@@ -78,7 +78,9 @@ class BarCodeReader(object):
                 fn = fn_or_im
             file_uris.append(pathlib.Path(fn).absolute().as_uri())
 
-        cmd = [self.java, '-cp', self.classpath, self.cls] + file_uris
+        cmd = [self.java, '-cp', self.classpath, self.cls]
+        if self.zxing_version_info and self.zxing_version_info >= (3, 5, 0):
+            cmd.append('--raw')
         if try_harder:
             cmd.append('--try_harder')
         if pure_barcode:
@@ -88,6 +90,7 @@ class BarCodeReader(object):
         if possible_formats:
             for pf in possible_formats:
                 cmd += ['--possible_formats', pf]
+        cmd += file_uris
 
         try:
             p = sp.Popen(cmd, stdout=sp.PIPE, stderr=sp.STDOUT, universal_newlines=False)
@@ -145,6 +148,7 @@ class CLROutputBlock(Enum):
     RAW = 1
     PARSED = 2
     POINTS = 3
+    RAW_BITS = 4
 
 
 class BarCode(object):
@@ -152,7 +156,7 @@ class BarCode(object):
     def parse(cls, zxing_output):
         block = CLROutputBlock.UNKNOWN
         uri = format = type = None
-        raw = parsed = b''
+        raw = parsed = raw_bits = b''
         points = []
 
         for l in zxing_output.splitlines(True):
@@ -170,25 +174,34 @@ class BarCode(object):
                 else:
                     raw += l
             elif block == CLROutputBlock.PARSED:
-                if re.match(rb"Found\s+\d+\s+result\s+points?", l):
+                if l.startswith(b"Raw bits:"):
+                    block = CLROutputBlock.RAW_BITS
+                elif re.match(rb"Found\s+\d+\s+result\s+points?", l):
                     block = CLROutputBlock.POINTS
                 else:
                     parsed += l
+            elif block == CLROutputBlock.RAW_BITS:
+                if re.match(rb"Found\s+\d+\s+result\s+points?", l):
+                    block = CLROutputBlock.POINTS
+                else:
+                    raw_bits += l
             elif block == CLROutputBlock.POINTS:
                 m = re.match(rb"\s*Point\s*\d+:\s*\(([\d.]+),([\d.]+)\)", l)
                 if m:
                     points.append((float(m.group(1)), float(m.group(2))))
 
-        raw = raw[:-1].decode()
         parsed = parsed[:-1].decode()
-        return cls(uri, format, type, raw, parsed, points)
+        raw = raw[:-1].decode()
+        raw_bits = bytes.fromhex(raw_bits[:-1].decode())
+        return cls(uri, format, type, raw, parsed, raw_bits, points)
 
     def __bool__(self):
         return bool(self.raw)
 
-    def __init__(self, uri, format=None, type=None, raw=None, parsed=None, points=None):
+    def __init__(self, uri, format=None, type=None, raw=None, parsed=None, raw_bits=None, points=None):
         self.raw = raw
         self.parsed = parsed
+        self.raw_bits = raw_bits
         self.uri = uri
         self.format = format
         self.type = type
@@ -202,7 +215,7 @@ class BarCode(object):
             pass
 
     def __repr__(self):
-        return '{}(raw={!r}, parsed={!r}, {}={!r}, format={!r}, type={!r}, points={!r})'.format(
-            self.__class__.__name__, self.raw, self.parsed,
+        return '{}(raw={!r}, parsed={!r}, raw_bits={!r:x}, {}={!r}, format={!r}, type={!r}, points={!r})'.format(
+            self.__class__.__name__, self.raw, self.parsed, self.raw_bits,
             'path' if self.path else 'uri', self.path or self.uri,
             self.format, self.type, self.points)

--- a/zxing/__main__.py
+++ b/zxing/__main__.py
@@ -42,7 +42,8 @@ def main():
             else:
                 print("  Decoded %s barcode in %s format." % (bc.type, bc.format))
                 print("  Raw text:    %r" % bc.raw)
-                print("  Parsed text: %r\n" % bc.parsed)
+                print("  Parsed text: %r" % bc.parsed)
+                print("  Raw bits:    %r\n" % bc.raw_bits.hex())
 
 
 if __name__=='__main__':


### PR DESCRIPTION
Hi, thanks for your great project. Since the option to output the raw bits contained in the barcode has been added to the command line runner of zxing in v3.5.0, this can now be captured in this wrapper.
Proposed changes:
- Update the dependencies to the current version (v3.5.1) and jcommander to match the expected version
- Add the option '--raw' to the invocation if the detected version is at least 3.5.0
- Add a further field raw_bits to the BarCode class that stores the raw bits output (this might be a bit confusing given that there is an existing field name raw, but this is the least-breaking change)

Notes:
- The parse method supports parsing the raw bits output, but is also fine if its missing
- As the existing logic to determine the zxing version doesn't work correctly, if the classpath is overriden via parameter / environment variable, this change will lead to call failures if a pre-3.5.0 version of zxing is passed via parameter / environment.