### PR TITLE
Fix missing requirements files in sdist

### DIFF
--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -33,9 +33,14 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Build
+    - name: Build sdist
       run: |
-        python setup.py sdist
+        python -m pip install build
+        python -m build --sdist .
+    - name: Verify sdist
+      run: |
+        tar -tvf dist/*.tar.gz | { grep -F /requirements.txt; }
+        tar -tvf dist/*.tar.gz | { grep -F /requirements-test.txt; }
     - name: Store distribution packages
       uses: actions/upload-artifact@v3
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 dist/*
 *.pyc
 zxing/java/
+*.egg-info

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements*.txt


### PR DESCRIPTION
Make sure to bundle the `requirements*.txt` files inside the source distributions as they are loaded at install time. Should resolve #32.