### PR TITLE
Proposed fixes to #40

### DIFF
--- a/zxing/__init__.py
+++ b/zxing/__init__.py
@@ -147,7 +147,7 @@ class BarCodeReader(object):
 
         file_results = []
         for line in stdout.splitlines(True):
-            if line.startswith((b'file:///', b'Exception')):
+            if line.startswith((b'file://', b'Exception')):
                 file_results.append(line)
             else:
                 file_results[-1] += line
@@ -180,7 +180,7 @@ class BarCode(object):
 
         for l in zxing_output.splitlines(True):
             if block == CLROutputBlock.UNKNOWN:
-                if l.endswith(b': No barcode found\n'):
+                if l.strip().endswith(b': No barcode found'):
                     return cls(l.rsplit(b':', 1)[0].decode(), None, None, None, None, None)
                 m = re.match(rb"(\S+) \(format:\s*([^,]+),\s*type:\s*([^)]+)\)", l)
                 if m:


### PR DESCRIPTION
Fixes for the errors in https://github.com/dlenski/python-zxing/issues/40.

- Error 1: suggested solution is to use `l.strip().endswith(b': No barcode found')`. The call to .strip() removes the end of line formatting all together and so it should work just fine on either OS.
- Error2: suggested solution is to replace `b'file:///'` with `b'file://'` as technically `b'file:///'` is just a shorthand for `b'file://localhost/'`